### PR TITLE
Fix email template link on alerts

### DIFF
--- a/application/controllers/scheduler/s_alerts.php
+++ b/application/controllers/scheduler/s_alerts.php
@@ -59,7 +59,7 @@ class S_Alerts_Controller extends Controller {
 		$alerts_email = ($settings['alerts_email']) ? $settings['alerts_email']
 			: $settings['site_email'];
 		$unsubscribe_message = Kohana::lang('alerts.unsubscribe')
-								.url::site().'alerts/unsubscribe/';
+							        .' '.url::site().'alerts/unsubscribe/';
 
 				$database_settings = kohana::config('database'); //around line 33
 				$this->table_prefix = $database_settings['default']['table_prefix']; //around line 34


### PR DESCRIPTION
Arreglar la plantilla del correo de alertas. Cierra el ticket #56

Es en el único sitio del código que encontré que se usé 'alerts.unsubscribe'.
